### PR TITLE
Added `RequireAbstractOrFinal`. Increased minimal PHP version

### DIFF
--- a/PSR12Ext/ruleset.xml
+++ b/PSR12Ext/ruleset.xml
@@ -44,6 +44,9 @@
     <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation" />
     <rule ref="SlevomatCodingStandard.Classes.ClassStructure" />
     <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants" />
+    <rule ref="SlevomatCodingStandard.Classes.RequireAbstractOrFinal">
+        <exclude-pattern>*/Entity/*</exclude-pattern>
+    </rule>>
     <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding" />
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch" />
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator" />

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This file can include the list of rule you want to disable as well as your custo
     <description>Local Project Coding Standard</description>
 
     <!-- Excludes vendor and temporary folders -->
-    <exclude-pattern>*/vendor/*</exclude-pattern>
-    <exclude-pattern>*/var/*</exclude-pattern>
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>var/*</exclude-pattern>
     <exclude-pattern>tests/_support/*</exclude-pattern>
 
     <!-- Base standards -->
@@ -79,6 +79,7 @@ Below you can find only the name of the rules:
 * SlevomatCodingStandard.Classes.MethodSpacing
 * SlevomatCodingStandard.Classes.ModernClassNameReference
 * SlevomatCodingStandard.Classes.PropertySpacing
+* SlevomatCodingStandard.Classes.RequireAbstractOrFinal
 * SlevomatCodingStandard.Classes.TraitUseSpacing
 * SlevomatCodingStandard.Classes.UselessLateStaticBinding
 * SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": "^7.2|^8.0",
         "squizlabs/php_codesniffer": "^3.6",
-        "slevomat/coding-standard": "^7.0"
+        "slevomat/coding-standard": "^7.2"
     },
     "support": {
         "source": "https://github.com/roslov/psr12ext"


### PR DESCRIPTION
* Added `SlevomatCodingStandard.Classes.RequireAbstractOrFinal`
* Increased minimal PHP version to 7.2
* Upgraded Slevomat Coding Standard to v7.2.0