### PR TITLE
Added attribute, enum, length, cognitive and other sniffs

### DIFF
--- a/PSR12Ext/ruleset.xml
+++ b/PSR12Ext/ruleset.xml
@@ -43,6 +43,11 @@
     <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation" />
     <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace" />
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma" />
+    <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing" />
+    <rule ref="SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine" />
+    <rule ref="SlevomatCodingStandard.Attributes.DisallowAttributesJoining" />
+    <rule ref="SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment" />
+    <rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
     <rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.ClassStructure" />
@@ -50,6 +55,7 @@
     <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants" />
     <rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition" />
     <rule ref="SlevomatCodingStandard.Classes.DisallowMultiPropertyDefinition" />
+    <rule ref="SlevomatCodingStandard.Classes.ClassLength" />
     <rule ref="SlevomatCodingStandard.Classes.MethodSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference" />
     <rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration" />
@@ -83,6 +89,7 @@
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment" />
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration" />
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment" />
+    <rule ref="SlevomatCodingStandard.Complexity.Cognitive" />
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch" />
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses" />
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator" />
@@ -92,6 +99,7 @@
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
     <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch" />
+    <rule ref="SlevomatCodingStandard.Files.FileLength" />
     <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration" />
     <rule ref="SlevomatCodingStandard.Functions.DisallowEmptyFunction" />
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
@@ -116,6 +124,7 @@
     <rule ref="SlevomatCodingStandard.Operators.SpreadOperatorSpacing" />
     <rule ref="SlevomatCodingStandard.PHP.ForbiddenClasses" />
     <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking" />
+    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion" />
     <rule ref="SlevomatCodingStandard.PHP.ShortList" />
     <rule ref="SlevomatCodingStandard.PHP.UselessParentheses" />
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon" />

--- a/PSR12Ext/ruleset.xml
+++ b/PSR12Ext/ruleset.xml
@@ -40,70 +40,29 @@
     <rule ref="Generic.Formatting.SpaceAfterCast" />
 
     <!-- Rules from Slevomat Coding Standard -->
-    <!-- Functional — improving the safety and behaviour of code -->
     <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation" />
-    <rule ref="SlevomatCodingStandard.Classes.ClassStructure" />
-    <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants" />
-    <rule ref="SlevomatCodingStandard.Classes.RequireAbstractOrFinal">
-        <exclude-pattern>*/Entity/*</exclude-pattern>
-    </rule>>
-    <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding" />
-    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch" />
-    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator" />
-    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator" />
-    <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
-    <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch" />
-    <rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
-    <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator" />
-    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
-        <properties>
-            <property name="linesCountBeforeDeclare" value="1" />
-            <property name="linesCountBeforeDeclare" value="1" />
-            <property name="spacesCountAroundEqualsSign" value="0" />
-        </properties>
-    </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint" />
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint" />
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint" />
-    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat" />
-    <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint" />
-
-    <!-- Cleaning — detecting dead code -->
-    <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
-    <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
-    <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue" />
-    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
-        <properties>
-            <property name="searchAnnotations" value="true" />
-        </properties>
-    </rule>
-    <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias" />
-    <rule ref="SlevomatCodingStandard.PHP.ForbiddenClasses" />
-    <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking" />
-    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses" />
-    <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon" />
-    <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable" />
-    <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable" />
-    <rule ref="SlevomatCodingStandard.Variables.UnusedVariable" />
-    <rule ref="SlevomatCodingStandard.Variables.UselessVariable" />
-
-    <!-- Formatting — rules for consistent code looks -->
     <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace" />
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma" />
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
     <rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing" />
+    <rule ref="SlevomatCodingStandard.Classes.ClassStructure" />
     <rule ref="SlevomatCodingStandard.Classes.ConstantSpacing" />
+    <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants" />
     <rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition" />
     <rule ref="SlevomatCodingStandard.Classes.DisallowMultiPropertyDefinition" />
     <rule ref="SlevomatCodingStandard.Classes.MethodSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference" />
     <rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration" />
     <rule ref="SlevomatCodingStandard.Classes.PropertySpacing" />
+    <rule ref="SlevomatCodingStandard.Classes.RequireAbstractOrFinal">
+        <exclude-pattern>*/Entity/*</exclude-pattern>
+    </rule>>
     <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing">
         <properties>
             <property name="linesCountBeforeFirstUse" value="0" />
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding" />
     <rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration" />
     <rule ref="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode" />
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
@@ -124,11 +83,20 @@
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment" />
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration" />
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment" />
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch" />
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses" />
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator" />
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator" />
     <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn" />
     <rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator" />
+    <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
+    <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
+    <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch" />
     <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration" />
     <rule ref="SlevomatCodingStandard.Functions.DisallowEmptyFunction" />
+    <rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
+    <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
+    <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue" />
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse" />
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine" />
@@ -136,15 +104,42 @@
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing" />
     <rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile" />
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
+    <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias" />
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" value="true" />
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing" />
     <rule ref="SlevomatCodingStandard.Operators.NegationOperatorSpacing" />
+    <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator" />
     <rule ref="SlevomatCodingStandard.Operators.SpreadOperatorSpacing" />
+    <rule ref="SlevomatCodingStandard.PHP.ForbiddenClasses" />
+    <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking" />
     <rule ref="SlevomatCodingStandard.PHP.ShortList" />
+    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses" />
+    <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon" />
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="linesCountBeforeDeclare" value="1" />
+            <property name="linesCountBeforeDeclare" value="1" />
+            <property name="spacesCountAroundEqualsSign" value="0" />
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints" />
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
     <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition" />
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint" />
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing" />
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint" />
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint" />
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" />
+    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat" />
+    <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint" />
+    <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable" />
+    <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable" />
+    <rule ref="SlevomatCodingStandard.Variables.UnusedVariable" />
+    <rule ref="SlevomatCodingStandard.Variables.UselessVariable" />
 
     <!-- Ignore declare new symbols and execute logic with side effects same file -->
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">

--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ Below you can find only the name of the rules:
 * SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation
 * SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace
 * SlevomatCodingStandard.Arrays.TrailingArrayComma
+* SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing
+* SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine
+* SlevomatCodingStandard.Attributes.DisallowAttributesJoining
+* SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment
+* SlevomatCodingStandard.Classes.BackedEnumTypeSpacing
 * SlevomatCodingStandard.Classes.ClassConstantVisibility
+* SlevomatCodingStandard.Classes.ClassLength
 * SlevomatCodingStandard.Classes.ClassMemberSpacing
 * SlevomatCodingStandard.Classes.ClassStructure
 * SlevomatCodingStandard.Classes.ConstantSpacing
@@ -95,6 +101,7 @@ Below you can find only the name of the rules:
 * SlevomatCodingStandard.Commenting.EmptyComment
 * SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration
 * SlevomatCodingStandard.Commenting.UselessFunctionDocComment
+* SlevomatCodingStandard.Complexity.Cognitive
 * SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch
 * SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses
 * SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator
@@ -104,6 +111,7 @@ Below you can find only the name of the rules:
 * SlevomatCodingStandard.Exceptions.DeadCatch
 * SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly
 * SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch
+* SlevomatCodingStandard.Files.FileLength
 * SlevomatCodingStandard.Functions.ArrowFunctionDeclaration
 * SlevomatCodingStandard.Functions.DisallowEmptyFunction
 * SlevomatCodingStandard.Functions.StaticClosure
@@ -124,6 +132,7 @@ Below you can find only the name of the rules:
 * SlevomatCodingStandard.Operators.SpreadOperatorSpacing
 * SlevomatCodingStandard.PHP.ForbiddenClasses
 * SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking
+* SlevomatCodingStandard.PHP.RequireExplicitAssertion
 * SlevomatCodingStandard.PHP.ShortList
 * SlevomatCodingStandard.PHP.UselessParentheses
 * SlevomatCodingStandard.PHP.UselessSemicolon

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "squizlabs/php_codesniffer": "^3.7",
-        "slevomat/coding-standard": "^8.0"
+        "slevomat/coding-standard": "^8.8"
     },
     "support": {
         "source": "https://github.com/roslov/psr12ext"


### PR DESCRIPTION
Sniffs added:

* `SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing`
* `SlevomatCodingStandard.Attributes.DisallowAttributesJoining`
* `SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine`
* `SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment`
* `SlevomatCodingStandard.Classes.BackedEnumTypeSpacing`
* `SlevomatCodingStandard.Classes.ClassLength`
* `SlevomatCodingStandard.Complexity.Cognitive`
* `SlevomatCodingStandard.Files.FileLength`
* `SlevomatCodingStandard.PHP.RequireExplicitAssertion`