### PR TITLE
Fix ruleset XML typo

### DIFF
--- a/PSR12Ext/ruleset.xml
+++ b/PSR12Ext/ruleset.xml
@@ -91,7 +91,7 @@
     <rule ref="SlevomatCodingStandard.Classes.PropertySpacing" />
     <rule ref="SlevomatCodingStandard.Classes.RequireAbstractOrFinal">
         <exclude-pattern>*/Entity/*</exclude-pattern>
-    </rule>>
+    </rule>
     <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing">
         <properties>
             <property name="linesCountBeforeFirstUse" value="0" />
@@ -169,7 +169,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
             <property name="linesCountBeforeDeclare" value="1" />
-            <property name="linesCountBeforeDeclare" value="1" />
+            <property name="linesCountAfterDeclare" value="1" />
             <property name="spacesCountAroundEqualsSign" value="0" />
         </properties>
     </rule>


### PR DESCRIPTION
## Summary
- fix extraneous `>` in ruleset XML
- set correct `linesCountAfterDeclare` option

## Testing
- `jq '.' composer.json`
- `python3 - <<'EOF'
import xml.etree.ElementTree as ET
try:
    ET.parse('PSR12Ext/ruleset.xml')
    print('XML parsed OK')
except Exception as e:
    print('Error', e)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6849cf665ff4832cad95ccaeed71b53a