### PR TITLE
Fix README link to PHP_CodeSniffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository extends the [PSR-12 coding style](https://www.php-fig.org/psr/ps
 
 In addition to PSR-12 this coding style also contains some rules from
 the [Slevomat Coding Standard](https://github.com/slevomat/coding-standard)
-and [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
+and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
 
 
 Using This Code Style


### PR DESCRIPTION
## Summary
- update README hyperlink to official PHP_CodeSniffer repo

## Testing
- `composer validate --no-check-all --strict` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849d2c49604832cb891d06ca49f546d