### PR TITLE
Added new Slevomat sniffs

### DIFF
--- a/PSR12Ext/ruleset.xml
+++ b/PSR12Ext/ruleset.xml
@@ -64,7 +64,9 @@
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols" />
 
     <!-- Rules from Slevomat Coding Standard -->
+    <rule ref="SlevomatCodingStandard.Arrays.ArrayAccess" />
     <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation" />
+    <rule ref="SlevomatCodingStandard.Arrays.DisallowPartiallyKeyed" />
     <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace" />
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma" />
     <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing" />
@@ -73,31 +75,37 @@
             <property name="orderAlphabetically" value="true" />
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine" />
     <rule ref="SlevomatCodingStandard.Attributes.DisallowAttributesJoining" />
+    <rule ref="SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine" />
     <rule ref="SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment" />
     <rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
+    <rule ref="SlevomatCodingStandard.Classes.ClassLength" />
     <rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.ClassStructure" />
     <rule ref="SlevomatCodingStandard.Classes.ConstantSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants" />
     <rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition" />
     <rule ref="SlevomatCodingStandard.Classes.DisallowMultiPropertyDefinition" />
-    <rule ref="SlevomatCodingStandard.Classes.ClassLength" />
+    <rule ref="SlevomatCodingStandard.Classes.DisallowStringExpressionPropertyFetch" />
+    <rule ref="SlevomatCodingStandard.Classes.EnumCaseSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.MethodSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference" />
+    <rule ref="SlevomatCodingStandard.Classes.ParentCallSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration" />
     <rule ref="SlevomatCodingStandard.Classes.PropertySpacing" />
     <rule ref="SlevomatCodingStandard.Classes.RequireAbstractOrFinal">
         <exclude-pattern>*/Entity/*</exclude-pattern>
     </rule>
+    <rule ref="SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature" />
+    <rule ref="SlevomatCodingStandard.Classes.RequireSelfReference" />
     <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing">
         <properties>
             <property name="linesCountBeforeFirstUse" value="0" />
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding" />
+    <rule ref="SlevomatCodingStandard.Commenting.AnnotationName" />
     <rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration" />
     <rule ref="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode" />
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
@@ -120,9 +128,12 @@
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment" />
     <rule ref="SlevomatCodingStandard.Complexity.Cognitive" />
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch" />
+    <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing" />
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses" />
+    <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses" />
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator" />
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator" />
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator" />
     <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn" />
     <rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator" />
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
@@ -131,6 +142,8 @@
     <rule ref="SlevomatCodingStandard.Files.FileLength" />
     <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration" />
     <rule ref="SlevomatCodingStandard.Functions.DisallowEmptyFunction" />
+    <rule ref="SlevomatCodingStandard.Functions.NamedArgumentSpacing" />
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall" />
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
     <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
     <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue" />
@@ -166,6 +179,7 @@
     <rule ref="SlevomatCodingStandard.PHP.ShortList" />
     <rule ref="SlevomatCodingStandard.PHP.UselessParentheses" />
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon" />
+    <rule ref="SlevomatCodingStandard.Strings.DisallowVariableParsing" />
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
             <property name="linesCountBeforeDeclare" value="1" />

--- a/README.md
+++ b/README.md
@@ -128,13 +128,15 @@ Below you can find only names of the rules:
     * Generic.Arrays.DisallowLongArraySyntax
     * Generic.Formatting.SpaceAfterCast
     * PSR1.Files.SideEffects.FoundWithSymbols
+    * SlevomatCodingStandard.Arrays.ArrayAccess
     * SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation
+    * SlevomatCodingStandard.Arrays.DisallowPartiallyKeyed
     * SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace
     * SlevomatCodingStandard.Arrays.TrailingArrayComma
     * SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing
     * SlevomatCodingStandard.Attributes.AttributesOrder
-    * SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine
     * SlevomatCodingStandard.Attributes.DisallowAttributesJoining
+    * SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine
     * SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment
     * SlevomatCodingStandard.Classes.BackedEnumTypeSpacing
     * SlevomatCodingStandard.Classes.ClassConstantVisibility
@@ -145,13 +147,19 @@ Below you can find only names of the rules:
     * SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants
     * SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition
     * SlevomatCodingStandard.Classes.DisallowMultiPropertyDefinition
+    * SlevomatCodingStandard.Classes.DisallowStringExpressionPropertyFetch
+    * SlevomatCodingStandard.Classes.EnumCaseSpacing
     * SlevomatCodingStandard.Classes.MethodSpacing
     * SlevomatCodingStandard.Classes.ModernClassNameReference
+    * SlevomatCodingStandard.Classes.ParentCallSpacing
     * SlevomatCodingStandard.Classes.PropertyDeclaration
     * SlevomatCodingStandard.Classes.PropertySpacing
     * SlevomatCodingStandard.Classes.RequireAbstractOrFinal
+    * SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature
+    * SlevomatCodingStandard.Classes.RequireSelfReference
     * SlevomatCodingStandard.Classes.TraitUseSpacing
     * SlevomatCodingStandard.Classes.UselessLateStaticBinding
+    * SlevomatCodingStandard.Commenting.AnnotationName
     * SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration
     * SlevomatCodingStandard.Commenting.DisallowCommentAfterCode
     * SlevomatCodingStandard.Commenting.DocCommentSpacing
@@ -160,9 +168,12 @@ Below you can find only names of the rules:
     * SlevomatCodingStandard.Commenting.UselessFunctionDocComment
     * SlevomatCodingStandard.Complexity.Cognitive
     * SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch
+    * SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing
     * SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses
+    * SlevomatCodingStandard.ControlStructures.NewWithParentheses
     * SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator
     * SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator
+    * SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator
     * SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn
     * SlevomatCodingStandard.ControlStructures.UselessTernaryOperator
     * SlevomatCodingStandard.Exceptions.DeadCatch
@@ -171,6 +182,8 @@ Below you can find only names of the rules:
     * SlevomatCodingStandard.Files.FileLength
     * SlevomatCodingStandard.Functions.ArrowFunctionDeclaration
     * SlevomatCodingStandard.Functions.DisallowEmptyFunction
+    * SlevomatCodingStandard.Functions.NamedArgumentSpacing
+    * SlevomatCodingStandard.Functions.RequireTrailingCommaInCall
     * SlevomatCodingStandard.Functions.StaticClosure
     * SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure
     * SlevomatCodingStandard.Functions.UselessParameterDefaultValue
@@ -194,6 +207,7 @@ Below you can find only names of the rules:
     * SlevomatCodingStandard.PHP.ShortList
     * SlevomatCodingStandard.PHP.UselessParentheses
     * SlevomatCodingStandard.PHP.UselessSemicolon
+    * SlevomatCodingStandard.Strings.DisallowVariableParsing
     * SlevomatCodingStandard.TypeHints.DeclareStrictTypes
     * SlevomatCodingStandard.TypeHints.LongTypeHints
     * SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue


### PR DESCRIPTION
* SlevomatCodingStandard.Arrays.ArrayAccess
* SlevomatCodingStandard.Arrays.DisallowPartiallyKeyed
* SlevomatCodingStandard.Classes.DisallowStringExpressionPropertyFetch
* SlevomatCodingStandard.Classes.EnumCaseSpacing
* SlevomatCodingStandard.Classes.ParentCallSpacing
* SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature
* SlevomatCodingStandard.Classes.RequireSelfReference
* SlevomatCodingStandard.Commenting.AnnotationName
* SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing
* SlevomatCodingStandard.ControlStructures.NewWithParentheses
* SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator
* SlevomatCodingStandard.Functions.NamedArgumentSpacing
* SlevomatCodingStandard.Functions.RequireTrailingCommaInCall
* SlevomatCodingStandard.Strings.DisallowVariableParsing