### PR TITLE
Added new sniffs

### DIFF
--- a/PSR12Ext/ruleset.xml
+++ b/PSR12Ext/ruleset.xml
@@ -60,8 +60,45 @@
         </properties>
     </rule>
 
-    <!-- Ignores new symbol declaration and logic execution with side effects in the same file -->
-    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols" />
+    <!-- Other rules from CodeSniffer -->
+    <rule ref="Generic.CodeAnalysis.EmptyPHPStatement" />
+    <rule ref="Generic.CodeAnalysis.EmptyStatement" />
+    <rule ref="Generic.CodeAnalysis.JumbledIncrementer" />
+    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier" />
+    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter" />
+    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod" />
+    <rule ref="Generic.ControlStructures.DisallowYodaConditions" />
+    <rule ref="Generic.Files.EndFileNewline" />
+    <rule ref="Generic.Files.ExecutableFile" />
+    <rule ref="Generic.NamingConventions.InterfaceNameSuffix" />
+    <rule ref="Generic.NamingConventions.TraitNameSuffix" />
+    <rule ref="Generic.PHP.DisallowRequestSuperglobal" />
+    <rule ref="Generic.PHP.Syntax" />
+    <rule ref="Generic.Strings.UnnecessaryHeredoc" />
+    <rule ref="Generic.VersionControl.GitMergeConflict" />
+    <rule ref="Generic.WhiteSpace.HereNowdocIdentifierSpacing" />
+    <rule ref="Generic.WhiteSpace.SpreadOperatorSpacingAfter" />
+    <rule ref="PEAR.ControlStructures.ControlSignature" />
+    <rule ref="PSR1.Files.SideEffects" />
+    <rule ref="PSR12.Classes.AnonClassDeclaration" />
+    <rule ref="PSR12.Classes.ClosingBrace" />
+    <rule ref="PSR12.ControlStructures.BooleanOperatorPlacement" />
+    <rule ref="PSR12.ControlStructures.ControlStructureSpacing" />
+    <rule ref="PSR12.Files.DeclareStatement" />
+    <rule ref="PSR12.Files.FileHeader" />
+    <rule ref="PSR12.Files.ImportStatement" />
+    <rule ref="PSR12.Files.OpenTag" />
+    <rule ref="PSR12.Functions.ReturnTypeDeclaration" />
+    <rule ref="PSR12.Properties.ConstantVisibility" />
+    <rule ref="PSR12.Traits.UseDeclaration" />
+    <rule ref="PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket" />
+    <rule ref="Squiz.Classes.ClassDeclaration" />
+    <rule ref="Squiz.Classes.LowercaseClassKeywords" />
+    <rule ref="Squiz.Commenting.DocCommentAlignment" />
+    <rule ref="Squiz.Commenting.PostStatementComment" />
+    <rule ref="Squiz.PHP.NonExecutableCode" />
+    <rule ref="Squiz.Scope.StaticThisUsage" />
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing" />
 
     <!-- Rules from Slevomat Coding Standard -->
     <rule ref="SlevomatCodingStandard.Arrays.ArrayAccess" />

--- a/README.md
+++ b/README.md
@@ -126,8 +126,39 @@ Below you can find only names of the rules:
     * Squiz.WhiteSpace.SuperfluousWhitespace.StartFile
 * **Custom rules:**
     * Generic.Arrays.DisallowLongArraySyntax
+    * Generic.CodeAnalysis.EmptyPHPStatement
+    * Generic.CodeAnalysis.EmptyStatement
+    * Generic.CodeAnalysis.JumbledIncrementer
+    * Generic.CodeAnalysis.UnnecessaryFinalModifier
+    * Generic.CodeAnalysis.UnusedFunctionParameter
+    * Generic.CodeAnalysis.UselessOverridingMethod
+    * Generic.ControlStructures.DisallowYodaConditions
+    * Generic.Files.EndFileNewline
+    * Generic.Files.ExecutableFile
     * Generic.Formatting.SpaceAfterCast
+    * Generic.NamingConventions.InterfaceNameSuffix
+    * Generic.NamingConventions.TraitNameSuffix
+    * Generic.PHP.DisallowRequestSuperglobal
+    * Generic.PHP.Syntax
+    * Generic.Strings.UnnecessaryHeredoc
+    * Generic.VersionControl.GitMergeConflict
+    * Generic.WhiteSpace.HereNowdocIdentifierSpacing
+    * Generic.WhiteSpace.SpreadOperatorSpacingAfter
+    * PEAR.ControlStructures.ControlSignature
+    * PSR1.Files.SideEffects
     * PSR1.Files.SideEffects.FoundWithSymbols
+    * PSR12.Classes.AnonClassDeclaration
+    * PSR12.Classes.ClosingBrace
+    * PSR12.ControlStructures.BooleanOperatorPlacement
+    * PSR12.ControlStructures.ControlStructureSpacing
+    * PSR12.Files.DeclareStatement
+    * PSR12.Files.FileHeader
+    * PSR12.Files.ImportStatement
+    * PSR12.Files.OpenTag
+    * PSR12.Functions.ReturnTypeDeclaration
+    * PSR12.Properties.ConstantVisibility
+    * PSR12.Traits.UseDeclaration
+    * PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket
     * SlevomatCodingStandard.Arrays.ArrayAccess
     * SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation
     * SlevomatCodingStandard.Arrays.DisallowPartiallyKeyed
@@ -224,8 +255,15 @@ Below you can find only names of the rules:
     * SlevomatCodingStandard.Variables.UnusedVariable
     * SlevomatCodingStandard.Variables.UselessVariable
     * SlevomatCodingStandard.Whitespaces.DuplicateSpaces
+    * Squiz.Classes.ClassDeclaration
+    * Squiz.Classes.LowercaseClassKeywords
+    * Squiz.Commenting.DocCommentAlignment
+    * Squiz.Commenting.PostStatementComment
+    * Squiz.PHP.NonExecutableCode
+    * Squiz.Scope.StaticThisUsage
     * Squiz.Strings.ConcatenationSpacing
     * Squiz.Strings.DoubleQuoteUsage.NotRequired
+    * Squiz.WhiteSpace.ControlStructureSpacing
     * Squiz.WhiteSpace.OperatorSpacing
 
 


### PR DESCRIPTION
* Generic.CodeAnalysis.EmptyPHPStatement
* Generic.CodeAnalysis.EmptyStatement
* Generic.CodeAnalysis.JumbledIncrementer
* Generic.CodeAnalysis.UnnecessaryFinalModifier
* Generic.CodeAnalysis.UnusedFunctionParameter
* Generic.CodeAnalysis.UselessOverridingMethod
* Generic.ControlStructures.DisallowYodaConditions
* Generic.Files.EndFileNewline
* Generic.Files.ExecutableFile
* Generic.NamingConventions.InterfaceNameSuffix
* Generic.NamingConventions.TraitNameSuffix
* Generic.PHP.DisallowRequestSuperglobal
* Generic.PHP.Syntax
* Generic.Strings.UnnecessaryHeredoc
* Generic.VersionControl.GitMergeConflict
* Generic.WhiteSpace.HereNowdocIdentifierSpacing
* Generic.WhiteSpace.SpreadOperatorSpacingAfter
* PEAR.ControlStructures.ControlSignature
* PSR1.Files.SideEffects
* PSR12.Classes.AnonClassDeclaration
* PSR12.Classes.ClosingBrace
* PSR12.ControlStructures.BooleanOperatorPlacement
* PSR12.ControlStructures.ControlStructureSpacing
* PSR12.Files.DeclareStatement
* PSR12.Files.FileHeader
* PSR12.Files.ImportStatement
* PSR12.Files.OpenTag
* PSR12.Functions.ReturnTypeDeclaration
* PSR12.Properties.ConstantVisibility
* PSR12.Traits.UseDeclaration
* PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket
* Squiz.Classes.ClassDeclaration
* Squiz.Classes.LowercaseClassKeywords
* Squiz.Commenting.DocCommentAlignment
* Squiz.Commenting.PostStatementComment
* Squiz.PHP.NonExecutableCode
* Squiz.Scope.StaticThisUsage
* Squiz.WhiteSpace.ControlStructureSpacing