### PR TITLE
Added `SlevomatCodingStandard.TypeHints.DNFTypeHintFormat`

### DIFF
--- a/PSR12Ext/ruleset.xml
+++ b/PSR12Ext/ruleset.xml
@@ -231,6 +231,7 @@
             <property name="spacesCountAroundEqualsSign" value="0" />
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat" />
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints" />
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
     <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition" />
@@ -239,7 +240,6 @@
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint" />
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint" />
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" />
-    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat" />
     <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint" />
     <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable" />
     <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable" />

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Below you can find only names of the rules:
     * SlevomatCodingStandard.PHP.UselessSemicolon
     * SlevomatCodingStandard.Strings.DisallowVariableParsing
     * SlevomatCodingStandard.TypeHints.DeclareStrictTypes
+    * SlevomatCodingStandard.TypeHints.DNFTypeHintFormat
     * SlevomatCodingStandard.TypeHints.LongTypeHints
     * SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue
     * SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition
@@ -250,7 +251,6 @@ Below you can find only names of the rules:
     * SlevomatCodingStandard.TypeHints.PropertyTypeHint
     * SlevomatCodingStandard.TypeHints.ReturnTypeHint
     * SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
-    * SlevomatCodingStandard.TypeHints.UnionTypeHintFormat
     * SlevomatCodingStandard.TypeHints.UselessConstantTypeHint
     * SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable
     * SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable


### PR DESCRIPTION
This commit also removes deprecated `SlevomatCodingStandard.TypeHints.UnionTypeHintFormat`.