### PR TITLE
Added new sniffs in Classes, Commenting, and Exceptions

### DIFF
--- a/PSR12Ext/ruleset.xml
+++ b/PSR12Ext/ruleset.xml
@@ -121,6 +121,7 @@
     <rule ref="SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment" />
     <rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
+    <rule ref="SlevomatCodingStandard.Classes.ClassKeywordOrder" />
     <rule ref="SlevomatCodingStandard.Classes.ClassLength" />
     <rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing" />
     <rule ref="SlevomatCodingStandard.Classes.ClassStructure" />
@@ -140,6 +141,7 @@
     </rule>
     <rule ref="SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature" />
     <rule ref="SlevomatCodingStandard.Classes.RequireSelfReference" />
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseOrder" />
     <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing">
         <properties>
             <property name="linesCountBeforeFirstUse" value="0" />
@@ -169,6 +171,7 @@
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment" />
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration" />
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneDocComment" />
+    <rule ref="SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder" />
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment" />
     <rule ref="SlevomatCodingStandard.Complexity.Cognitive" />
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch" />
@@ -180,6 +183,7 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator" />
     <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn" />
     <rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator" />
+    <rule ref="SlevomatCodingStandard.Exceptions.CatchExceptionsOrder" />
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
     <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch" />

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Below you can find only names of the rules:
     * PEAR.ControlStructures.ControlSignature
     * PSR1.Files.SideEffects
     * PSR1.Files.SideEffects.FoundWithSymbols
+    * PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket
     * PSR12.Classes.AnonClassDeclaration
     * PSR12.Classes.ClosingBrace
     * PSR12.ControlStructures.BooleanOperatorPlacement
@@ -164,7 +165,6 @@ Below you can find only names of the rules:
     * PSR12.Functions.ReturnTypeDeclaration
     * PSR12.Properties.ConstantVisibility
     * PSR12.Traits.UseDeclaration
-    * PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket
     * SlevomatCodingStandard.Arrays.ArrayAccess
     * SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation
     * SlevomatCodingStandard.Arrays.DisallowPartiallyKeyed
@@ -177,6 +177,7 @@ Below you can find only names of the rules:
     * SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment
     * SlevomatCodingStandard.Classes.BackedEnumTypeSpacing
     * SlevomatCodingStandard.Classes.ClassConstantVisibility
+    * SlevomatCodingStandard.Classes.ClassKeywordOrder
     * SlevomatCodingStandard.Classes.ClassLength
     * SlevomatCodingStandard.Classes.ClassMemberSpacing
     * SlevomatCodingStandard.Classes.ClassStructure
@@ -194,6 +195,7 @@ Below you can find only names of the rules:
     * SlevomatCodingStandard.Classes.RequireAbstractOrFinal
     * SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature
     * SlevomatCodingStandard.Classes.RequireSelfReference
+    * SlevomatCodingStandard.Classes.TraitUseOrder
     * SlevomatCodingStandard.Classes.TraitUseSpacing
     * SlevomatCodingStandard.Classes.UselessLateStaticBinding
     * SlevomatCodingStandard.Commenting.AnnotationName
@@ -203,6 +205,7 @@ Below you can find only names of the rules:
     * SlevomatCodingStandard.Commenting.EmptyComment
     * SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration
     * SlevomatCodingStandard.Commenting.RequireOneDocComment
+    * SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder
     * SlevomatCodingStandard.Commenting.UselessFunctionDocComment
     * SlevomatCodingStandard.Complexity.Cognitive
     * SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch
@@ -214,6 +217,7 @@ Below you can find only names of the rules:
     * SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator
     * SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn
     * SlevomatCodingStandard.ControlStructures.UselessTernaryOperator
+    * SlevomatCodingStandard.Exceptions.CatchExceptionsOrder
     * SlevomatCodingStandard.Exceptions.DeadCatch
     * SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly
     * SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "slevomat/coding-standard": "^8.25",
-        "squizlabs/php_codesniffer": "^4.0"
+        "slevomat/coding-standard": "^8.28.1",
+        "squizlabs/php_codesniffer": "^4.0.1"
     },
     "support": {
         "source": "https://github.com/roslov/psr12ext"


### PR DESCRIPTION
Added:
* `SlevomatCodingStandard.Classes.ClassKeywordOrder`
* `SlevomatCodingStandard.Classes.TraitUseOrder`
* `SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder`
* `SlevomatCodingStandard.Exceptions.CatchExceptionsOrder`